### PR TITLE
1st version complete....later might need to think of manytomany..tests missing...good to use

### DIFF
--- a/src/main/java/partio/PostgreSQLDatabaseGenerator.java
+++ b/src/main/java/partio/PostgreSQLDatabaseGenerator.java
@@ -32,6 +32,7 @@ public class PostgreSQLDatabaseGenerator {
         metadata.addAnnotatedClass(Event.class);
         metadata.addAnnotatedClass(EventGroup.class);
         metadata.addAnnotatedClass(Activity.class);
+        metadata.addAnnotatedClass(ActivityBuffer.class);
         SchemaExport schemaExport = new SchemaExport(
                 (MetadataImplementor) metadata.buildMetadata()
         );

--- a/src/main/java/partio/controller/ActivityBufferController.java
+++ b/src/main/java/partio/controller/ActivityBufferController.java
@@ -1,9 +1,7 @@
 package partio.controller;
 
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,19 +16,13 @@ public class ActivityBufferController {
     @Autowired
     private ActivityBufferService bufferService;
 
-    @PostMapping("/activityBuffer/{id}/activities/")
+    @PostMapping("/activitybuffer/{id}/activities/")
     public ResponseEntity<Object> postActivity(@PathVariable Long id, @RequestBody Activity activity) {
         return bufferService.addActivity(id, activity);
-    }
-    
-    @DeleteMapping("/activityBuffer/{id}/activities/{activityId}")
-    public ResponseEntity<Object> postActivity(@PathVariable Long id, @PathVariable Long activityId) {
-        return bufferService.deleteActivity(id, activityId);
     }
 
     @GetMapping("/activitybuffer/{id}")
     public ResponseEntity<Object> getBufferContent(@PathVariable Long id) {
-        System.out.println("aaaaaaaaa");
         return bufferService.getBufferContent(id);
     }
 }

--- a/src/main/java/partio/controller/ActivityBufferController.java
+++ b/src/main/java/partio/controller/ActivityBufferController.java
@@ -1,0 +1,36 @@
+package partio.controller;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import partio.domain.Activity;
+import partio.service.ActivityBufferService;
+
+@RestController
+public class ActivityBufferController {
+
+    @Autowired
+    private ActivityBufferService bufferService;
+
+    @PostMapping("/activityBuffer/{id}/activities/")
+    public ResponseEntity<Object> postActivity(@PathVariable Long id, @RequestBody Activity activity) {
+        return bufferService.addActivity(id, activity);
+    }
+    
+    @DeleteMapping("/activityBuffer/{id}/activities/{activityId}")
+    public ResponseEntity<Object> postActivity(@PathVariable Long id, @PathVariable Long activityId) {
+        return bufferService.deleteActivity(id, activityId);
+    }
+
+    @GetMapping("/activitybuffer/{id}")
+    public ResponseEntity<Object> getBufferContent(@PathVariable Long id) {
+        System.out.println("aaaaaaaaa");
+        return bufferService.getBufferContent(id);
+    }
+}

--- a/src/main/java/partio/controller/ActivityController.java
+++ b/src/main/java/partio/controller/ActivityController.java
@@ -36,9 +36,13 @@ public class ActivityController {
     }
     
      //new stuff from here
-    @PutMapping("/activity/")
-    public ResponseEntity<Object> put(@RequestBody Activity activity) {      
-        return activityService.restfulPut(activity);
+    
+    //this regular put is really hard to use because it requires event and buffer to be included
+    //(put replaces old object) and having to write event and buffer in json is a bitch
+    //after these put there are some not so restful but working ways to swap to/from event/buffer
+    @PutMapping("/activity/{id}")
+    public ResponseEntity<Object> put(@PathVariable long id, @RequestBody Activity activity) {      
+        return activityService.restfulPut(id, activity);
     }
    
     @PutMapping("/activity/{id}/fromevent/{eventId}/tobuffer/{bufferId}")

--- a/src/main/java/partio/controller/ActivityController.java
+++ b/src/main/java/partio/controller/ActivityController.java
@@ -37,14 +37,6 @@ public class ActivityController {
     
      //new stuff from here
     
-    //this regular put is really hard to use because it requires event and buffer to be included
-    //(put replaces old object) and having to write event and buffer in json is a bitch
-    //after these put there are some not so restful but working ways to swap to/from event/buffer
-    @PutMapping("/activity/{id}")
-    public ResponseEntity<Object> put(@PathVariable long id, @RequestBody Activity activity) {      
-        return activityService.restfulPut(id, activity);
-    }
-   
     @PutMapping("/activity/{id}/fromevent/{eventId}/tobuffer/{bufferId}")
     public ResponseEntity<Object> moveActivityFromEventToBuffer(@PathVariable Long id,
             @PathVariable Long eventId, 

--- a/src/main/java/partio/controller/ActivityController.java
+++ b/src/main/java/partio/controller/ActivityController.java
@@ -35,6 +35,12 @@ public class ActivityController {
         return activityService.list();
     }
     
+     //new stuff from here
+    @PutMapping("/activity/")
+    public ResponseEntity<Object> put(@RequestBody Activity activity) {      
+        return activityService.restfulPut(activity);
+    }
+   
     @PutMapping("/activity/{id}/fromevent/{eventId}/tobuffer/{bufferId}")
     public ResponseEntity<Object> moveActivityFromEventToBuffer(@PathVariable Long id,
             @PathVariable Long eventId, 

--- a/src/main/java/partio/controller/ActivityController.java
+++ b/src/main/java/partio/controller/ActivityController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import partio.domain.Activity;
@@ -34,14 +35,14 @@ public class ActivityController {
         return activityService.list();
     }
     
-    @PostMapping("/activity/{id}/fromevent/{eventId}/tobuffer/{bufferId}")
+    @PutMapping("/activity/{id}/fromevent/{eventId}/tobuffer/{bufferId}")
     public ResponseEntity<Object> moveActivityFromEventToBuffer(@PathVariable Long id,
             @PathVariable Long eventId, 
             @PathVariable Long bufferId) {
         
         return activityService.moveActivityFromEventToBuffer(id, eventId, bufferId);
     }
-    @PostMapping("/activity/{id}/frombuffer/{bufferId}/toevent/{eventId}")
+    @PutMapping("/activity/{id}/frombuffer/{bufferId}/toevent/{eventId}")
     public ResponseEntity<Object> moveActivityFromBufferToEvent(@PathVariable Long id,
             @PathVariable Long bufferId, 
             @PathVariable Long eventId) {

--- a/src/main/java/partio/controller/ActivityController.java
+++ b/src/main/java/partio/controller/ActivityController.java
@@ -19,13 +19,12 @@ public class ActivityController {
     @Autowired
     private ActivityService activityService;    
     
-    //tämän
     @DeleteMapping("/activities/{activityId}")
     public ResponseEntity<Object> deleteActivity(@PathVariable Long activityId) {
         return activityService.removeActivity(activityId);
     }
 
-    @PostMapping("events/{eventId}/activities")
+    @PostMapping("/events/{eventId}/activities")
     public ResponseEntity<Object> postActivity(@PathVariable Long eventId, @RequestBody Activity jsonActivity) {
         return activityService.addActivity(eventId, jsonActivity);
     }
@@ -35,4 +34,18 @@ public class ActivityController {
         return activityService.list();
     }
     
+    @PostMapping("/activity/{id}/fromevent/{eventId}/tobuffer/{bufferId}")
+    public ResponseEntity<Object> moveActivityFromEventToBuffer(@PathVariable Long id,
+            @PathVariable Long eventId, 
+            @PathVariable Long bufferId) {
+        
+        return activityService.moveActivityFromEventToBuffer(id, eventId, bufferId);
+    }
+    @PostMapping("/activity/{id}/frombuffer/{bufferId}/toevent/{eventId}")
+    public ResponseEntity<Object> moveActivityFromBufferToEvent(@PathVariable Long id,
+            @PathVariable Long bufferId, 
+            @PathVariable Long eventId) {
+        
+        return activityService.moveActivityFromBufferToEvent(id, eventId, bufferId);
+    }
 }

--- a/src/main/java/partio/controller/EventController.java
+++ b/src/main/java/partio/controller/EventController.java
@@ -1,7 +1,6 @@
 package partio.controller;
 
 import java.util.List;
-import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;

--- a/src/main/java/partio/domain/Activity.java
+++ b/src/main/java/partio/domain/Activity.java
@@ -2,7 +2,6 @@ package partio.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Objects;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;

--- a/src/main/java/partio/domain/Activity.java
+++ b/src/main/java/partio/domain/Activity.java
@@ -24,6 +24,11 @@ public class Activity extends AbstractPersistable<Long> {
     @ManyToOne
     @JoinColumn
     private Event event;
+    
+    @ManyToOne
+    @JoinColumn
+    private ActivityBuffer buffer;
+    
     //pof backend id
     private String guid;
 
@@ -38,6 +43,11 @@ public class Activity extends AbstractPersistable<Long> {
         }
         return false;
     }
+    
+    @Override
+    public String toString() {
+        return "guid: "+guid + " id: " + getId();
+    }
 
     @Override
     public int hashCode() {
@@ -45,4 +55,5 @@ public class Activity extends AbstractPersistable<Long> {
         hash = 59 * hash + Objects.hashCode(this.guid);
         return hash;
     }
+ 
 }

--- a/src/main/java/partio/domain/Activity.java
+++ b/src/main/java/partio/domain/Activity.java
@@ -20,17 +20,22 @@ import partio.jsonconfig.ActivitySerializer;
 //@EqualsAndHashCode(callSuper = false)
 @JsonSerialize(using = ActivitySerializer.class)
 public class Activity extends AbstractPersistable<Long> {
-
     @ManyToOne
     @JoinColumn
     private Event event;
     
     @ManyToOne
     @JoinColumn
-    private ActivityBuffer buffer;
     
+    private ActivityBuffer buffer;
     //pof backend id
     private String guid;
+    
+    //tests need this constructor
+    public Activity(Event event,String guid) {
+        this.guid = guid;
+        this.event=event;
+    }
 
     @Override
     public boolean equals(Object object) {

--- a/src/main/java/partio/domain/ActivityBuffer.java
+++ b/src/main/java/partio/domain/ActivityBuffer.java
@@ -19,6 +19,7 @@ import partio.jsonconfig.ActivityBufferSerializer;
 @Entity
 @JsonSerialize(using = ActivityBufferSerializer.class)
 public class ActivityBuffer extends AbstractPersistable<Long> {
+    public static final int BUFFER_SIZE = 5;
    // @JsonManagedReference
     @OneToMany(mappedBy = "buffer", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Activity> activities;

--- a/src/main/java/partio/domain/ActivityBuffer.java
+++ b/src/main/java/partio/domain/ActivityBuffer.java
@@ -1,0 +1,42 @@
+
+package partio.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import java.util.Objects;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.AbstractPersistable;
+import partio.jsonconfig.ActivityBufferSerializer;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Entity
+@JsonSerialize(using = ActivityBufferSerializer.class)
+public class ActivityBuffer extends AbstractPersistable<Long> {
+   // @JsonManagedReference
+    @OneToMany(mappedBy = "buffer", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Activity> activities;
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 37 * hash + Objects.hashCode(super.getId());
+        return hash;
+    }
+    
+    public boolean equals(Object other) {
+        if (other.getClass() != ActivityBuffer.class) {
+            return false;
+        }
+        ActivityBuffer otherGroup = (ActivityBuffer) other;
+        return this.getId() == otherGroup.getId();
+    }
+    
+
+}

--- a/src/main/java/partio/jsonconfig/ActivityBufferSerializer.java
+++ b/src/main/java/partio/jsonconfig/ActivityBufferSerializer.java
@@ -1,0 +1,49 @@
+
+package partio.jsonconfig;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+import java.math.BigDecimal;
+import partio.domain.Activity;
+import partio.domain.ActivityBuffer;
+
+
+public class ActivityBufferSerializer extends StdSerializer<ActivityBuffer> {
+
+    public ActivityBufferSerializer() {
+        this(null);
+    }
+   
+    public ActivityBufferSerializer(Class<ActivityBuffer> t) {
+        super(t);
+    }
+ 
+    @Override
+    public void serialize(
+      ActivityBuffer buffer, JsonGenerator jgen, SerializerProvider provider) 
+      throws IOException, JsonProcessingException {
+  
+        jgen.writeStartObject();
+        if (buffer.getActivities()!= null) {
+
+            jgen.writeNumberField("id", buffer.getId());
+            jgen.writeArrayFieldStart("activities");
+
+            for (Activity activity : buffer.getActivities()) {
+                jgen.writeStartObject();
+                jgen.writeNumberField("id", activity.getId());
+                jgen.writeStringField("guid", activity.getGuid());
+                jgen.writeEndObject();
+            }
+
+            jgen.writeEndArray();
+        } else {
+            jgen.writeStringField("activities", null);
+        }
+        jgen.writeEndObject();
+    }
+    
+}

--- a/src/main/java/partio/jsonconfig/ActivitySerializer.java
+++ b/src/main/java/partio/jsonconfig/ActivitySerializer.java
@@ -26,7 +26,14 @@ public class ActivitySerializer extends StdSerializer<Activity> {
         jgen.writeStartObject();
         jgen.writeNumberField("id", value.getId());
         jgen.writeStringField("guid", value.getGuid());
+        if (value.getEvent() != null) {
         jgen.writeNumberField("eventId", value.getEvent().getId());
+        } else {
+            jgen.writeNumberField("eventId", null);
+        }
+        //buffer is not here because a) a singleton b) there will be 1 buffer per user
+        //that means basically find buffer by user and all activities of 1 user would have same bufferId
+        //this is why frontend shoudnt need it
         jgen.writeEndObject();
     }
         

--- a/src/main/java/partio/repository/ActivityBufferRepository.java
+++ b/src/main/java/partio/repository/ActivityBufferRepository.java
@@ -1,0 +1,9 @@
+
+package partio.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import partio.domain.ActivityBuffer;
+
+public interface ActivityBufferRepository extends JpaRepository<ActivityBuffer, Long>{
+
+}

--- a/src/main/java/partio/service/ActivityBufferService.java
+++ b/src/main/java/partio/service/ActivityBufferService.java
@@ -1,0 +1,76 @@
+package partio.service;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import partio.domain.Activity;
+import partio.domain.ActivityBuffer;
+import partio.repository.ActivityBufferRepository;
+import partio.repository.ActivityRepository;
+import partio.service.validators.ActivityValidator;
+
+@Service
+@Transactional
+public class ActivityBufferService {
+
+    @Autowired
+    private ActivityBufferRepository bufferRepository;
+    @Autowired
+    private ActivityRepository activityRepository;
+    @Autowired
+    private ActivityValidator activityValidator;
+
+    //because we dont have multiuser support yet i made it to create one if one does not exist
+    //will always return same one
+    public ActivityBuffer findBuffer(Long id) {
+        if (bufferRepository.count() == 0) {
+            ActivityBuffer buffer = new ActivityBuffer();
+            bufferRepository.save(buffer);
+            return buffer;
+
+        } else {
+            return bufferRepository.findAll().get(0);
+        }
+    }
+
+    public ResponseEntity<Object> getBufferContent(Long id) {
+        ActivityBuffer buffer = findBuffer(id);
+        System.out.println(buffer);
+        if (buffer == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+        return ResponseEntity.ok(buffer);
+    }
+
+    public ResponseEntity<Object> addActivity(Long ActivityBufferId, Activity activity) {
+        ActivityBuffer buffer = findBuffer(ActivityBufferId);
+        if (buffer == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+
+        activity.setBuffer(buffer);
+        List<String> errors = activityValidator.validateNew(activity);
+        if (!errors.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+        }
+
+        activityRepository.save(activity);
+        buffer.getActivities().add(activity);
+
+        bufferRepository.save(buffer);
+        return ResponseEntity.ok(buffer);
+    }
+
+    public ResponseEntity<Object> deleteActivity(Long ActivityBufferId, long activityId) {
+        ActivityBuffer buffer = findBuffer(ActivityBufferId);
+
+        if (buffer == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+        return ResponseEntity.ok(buffer);
+    }
+
+}

--- a/src/main/java/partio/service/ActivityBufferService.java
+++ b/src/main/java/partio/service/ActivityBufferService.java
@@ -1,5 +1,6 @@
 package partio.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -58,6 +59,9 @@ public class ActivityBufferService {
         }
 
         activityRepository.save(activity);
+        if (buffer.getActivities() == null) {
+            buffer.setActivities(new ArrayList<>());
+        }
         buffer.getActivities().add(activity);
 
         bufferRepository.save(buffer);

--- a/src/main/java/partio/service/ActivityBufferService.java
+++ b/src/main/java/partio/service/ActivityBufferService.java
@@ -64,13 +64,4 @@ public class ActivityBufferService {
         return ResponseEntity.ok(buffer);
     }
 
-    public ResponseEntity<Object> deleteActivity(Long ActivityBufferId, long activityId) {
-        ActivityBuffer buffer = findBuffer(ActivityBufferId);
-
-        if (buffer == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
-        }
-        return ResponseEntity.ok(buffer);
-    }
-
 }

--- a/src/main/java/partio/service/ActivityService.java
+++ b/src/main/java/partio/service/ActivityService.java
@@ -62,35 +62,18 @@ public class ActivityService {
     }
 
     //new stuff from here
-    public ResponseEntity<Object> restfulPut(long id, Activity activity) {
-        System.out.println(activity);
-        Activity original = activityRepository.findOne(id);
-        if (original == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
-        }
-
-        List<String> errors = validator.validateChanges(original, activity);
-        if (!errors.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
-        }
-
-        activityRepository.save(activity);
-        return ResponseEntity.ok(activity);
-    }
-
+   
     public ResponseEntity<Object> moveActivityFromEventToBuffer(Long activityId, Long eventId, Long activityBufferId) {
         Activity activity = activityRepository.findOne(activityId);
-        /*   if (activity == null) {
+           if (activity == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
         }
         Event from = eventRepository.findOne(eventId);
         ActivityBuffer to = bufferService.findBuffer(eventId);
-        if (!from.getActivities().contains(activity)) {
+        if ((from == null || from.getActivities() == null || !from.getActivities().contains(activity)) || to == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
-        }*/
+        }
 
-        Event from = eventRepository.findOne(eventId);
-        ActivityBuffer to = bufferService.findBuffer(eventId);
         if (to.getActivities() != null && to.getActivities().size() >= ActivityBuffer.BUFFER_SIZE) {
             activityRepository.delete(activity);
             return ResponseEntity.status(HttpStatus.NO_CONTENT).body(activity);
@@ -98,10 +81,6 @@ public class ActivityService {
 
         activity.setBuffer(to);
         activity.setEvent(null);
-        List<String> errors = validator.validateChanges(activityRepository.findOne(activityId), activity);
-        if (!errors.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
-        }
         activityRepository.save(activity);
 
         return ResponseEntity.ok(activity);
@@ -115,7 +94,7 @@ public class ActivityService {
         Event to = eventRepository.findOne(eventId);
         ActivityBuffer from = bufferService.findBuffer(eventId);
 
-        if (!from.getActivities().contains(activity)) {
+        if (from == null || from.getActivities() == null || !from.getActivities().contains(activity)) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
         }
 

--- a/src/main/java/partio/service/ActivityService.java
+++ b/src/main/java/partio/service/ActivityService.java
@@ -8,7 +8,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import partio.domain.Activity;
+import partio.domain.ActivityBuffer;
 import partio.domain.Event;
+import partio.repository.ActivityBufferRepository;
 import partio.repository.ActivityRepository;
 import partio.repository.EventRepository;
 import partio.service.validators.ActivityValidator;
@@ -18,38 +20,35 @@ import partio.service.validators.ActivityValidator;
 public class ActivityService {
 
     @Autowired
+    private ActivityBufferRepository bufferRepository;
+    @Autowired
     private EventRepository eventRepository;
     @Autowired
     private ActivityRepository activityRepository;
     @Autowired
     private ActivityValidator validator;
+    @Autowired
+    private ActivityBufferService bufferService;
 
     public ResponseEntity<Object> addActivity(Long eventId, Activity activity) {
-
         Event event = eventRepository.findOne(eventId);
         if (event == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
         }
-
         List<String> errors = validator.validateNew(activity);
-        
         //for when we move onto next step (right now only uniq activities are allowed)
         //another suggestion would be adding if activity is not finished 
         //can add same acitivity
-        
         //  if (event.getActivities().contains(guid)) {
         //    errors.add("Event can't have same activity more than once.");
         //  }
         if (!errors.isEmpty()) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
         }
-
         activity.setEvent(event);
         activityRepository.save(activity);
-
         event.getActivities().add(activity);
         eventRepository.save(event);
-
         return ResponseEntity.ok(activity);
     }
 
@@ -64,6 +63,50 @@ public class ActivityService {
 
     public List<Activity> list() {
         return activityRepository.findAll();
+    }
+    
+      private boolean allExistsForEventAndActivityAndBuffer(Long activityId, Long eventId, Long ActivityBufferId) {
+        return (bufferRepository.exists(bufferService.findBuffer(ActivityBufferId).getId()) &&
+                activityRepository.exists(activityId) &&
+                eventRepository.exists(eventId));
+    }
+
+    public ResponseEntity<Object> moveActivityFromEventToBuffer(Long activityId, Long eventId, Long activityBufferId) {
+        if (!allExistsForEventAndActivityAndBuffer(activityId, eventId, activityBufferId)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+        Activity activity = activityRepository.findOne(activityId);
+        Event from = eventRepository.findOne(eventId);
+        ActivityBuffer to = bufferService.findBuffer(eventId);
+        
+        if (!from.getActivities().contains(activity)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+        
+        activity.setBuffer(to);
+        activity.setEvent(null);
+        activityRepository.save(activity);
+        
+        return ResponseEntity.ok(null);
+    }
+
+    public ResponseEntity<Object> moveActivityFromBufferToEvent(Long activityId, Long activityBufferId, Long eventId) {
+        if (!allExistsForEventAndActivityAndBuffer(activityId, eventId, activityBufferId)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+        Activity activity = activityRepository.findOne(activityId);
+        Event to = eventRepository.findOne(eventId);
+        ActivityBuffer from = bufferService.findBuffer(eventId);
+        
+        if (!from.getActivities().contains(activity)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+        
+        activity.setBuffer(null);
+        activity.setEvent(to);
+        activityRepository.save(activity);
+        
+        return ResponseEntity.ok(null);
     }
 
 }

--- a/src/main/java/partio/service/ActivityService.java
+++ b/src/main/java/partio/service/ActivityService.java
@@ -80,13 +80,20 @@ public class ActivityService {
 
     public ResponseEntity<Object> moveActivityFromEventToBuffer(Long activityId, Long eventId, Long activityBufferId) {
         Activity activity = activityRepository.findOne(activityId);
-        if (activity == null) {
+        /*   if (activity == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
         }
         Event from = eventRepository.findOne(eventId);
         ActivityBuffer to = bufferService.findBuffer(eventId);
         if (!from.getActivities().contains(activity)) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }*/
+
+        Event from = eventRepository.findOne(eventId);
+        ActivityBuffer to = bufferService.findBuffer(eventId);
+        if (to.getActivities() != null && to.getActivities().size() >= ActivityBuffer.BUFFER_SIZE) {
+            activityRepository.delete(activity);
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).body(activity);
         }
 
         activity.setBuffer(to);

--- a/src/main/java/partio/service/validators/ActivityValidator.java
+++ b/src/main/java/partio/service/validators/ActivityValidator.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import partio.domain.Activity;
+import partio.domain.ActivityBuffer;
 import partio.repository.ActivityBufferRepository;
 import partio.repository.ActivityRepository;
 import partio.repository.EventRepository;
@@ -41,6 +42,7 @@ public class ActivityValidator extends Validator<Activity> {
         return errors;
     }
 
+    @Override
     public List<String> validateChanges(Activity original, Activity changes) {
         List<String> errors = validateNewAndOld(changes);
         if (original.getGuid().equals(changes.getGuid()) == false) {
@@ -58,10 +60,19 @@ public class ActivityValidator extends Validator<Activity> {
            }
         }
         if (t.getBuffer()!= null) {
-           if (bufferRepository.exists(t.getBuffer().getId()) == false) {
+            ActivityBuffer bufferInDb = bufferRepository.findOne(t.getBuffer().getId());
+           if (bufferInDb == null) {
                errors.add("buffer of activity is not found in db.");
+           } else if (bufferInDb.getActivities() != null &&
+                   bufferInDb.getActivities().size() > ActivityBuffer.BUFFER_SIZE) {                  
+                errors.add("buffer is full.");
+           }
+           if (t.getEvent() != null) {
+               errors.add("Activity can exist only in event OR in buffer");
            }
         }
+        
+        
 
         return errors;
     }

--- a/src/main/java/partio/service/validators/ActivityValidator.java
+++ b/src/main/java/partio/service/validators/ActivityValidator.java
@@ -44,13 +44,7 @@ public class ActivityValidator extends Validator<Activity> {
 
     @Override
     public List<String> validateChanges(Activity original, Activity changes) {
-         List<String> errors;
-        if (original == null) {
-            errors = new ArrayList<>();
-            errors.add(("original activity not found!"));
-            return errors;
-        }
-       errors = validateNewAndOld(changes);
+        List<String> errors = validateNewAndOld(changes);
         if (original.getGuid().equals(changes.getGuid()) == false) {
             errors.add("guid is not allowed to change");
         }
@@ -69,7 +63,10 @@ public class ActivityValidator extends Validator<Activity> {
             ActivityBuffer bufferInDb = bufferRepository.findOne(t.getBuffer().getId());
            if (bufferInDb == null) {
                errors.add("buffer of activity is not found in db.");
-           } 
+           } else if (bufferInDb.getActivities() != null &&
+                   bufferInDb.getActivities().size() > ActivityBuffer.BUFFER_SIZE) {                  
+                errors.add("buffer is full.");
+           }
            if (t.getEvent() != null) {
                errors.add("Activity can exist only in event OR in buffer");
            }

--- a/src/main/java/partio/service/validators/ActivityValidator.java
+++ b/src/main/java/partio/service/validators/ActivityValidator.java
@@ -44,7 +44,13 @@ public class ActivityValidator extends Validator<Activity> {
 
     @Override
     public List<String> validateChanges(Activity original, Activity changes) {
-        List<String> errors = validateNewAndOld(changes);
+         List<String> errors;
+        if (original == null) {
+            errors = new ArrayList<>();
+            errors.add(("original activity not found!"));
+            return errors;
+        }
+       errors = validateNewAndOld(changes);
         if (original.getGuid().equals(changes.getGuid()) == false) {
             errors.add("guid is not allowed to change");
         }
@@ -63,10 +69,7 @@ public class ActivityValidator extends Validator<Activity> {
             ActivityBuffer bufferInDb = bufferRepository.findOne(t.getBuffer().getId());
            if (bufferInDb == null) {
                errors.add("buffer of activity is not found in db.");
-           } else if (bufferInDb.getActivities() != null &&
-                   bufferInDb.getActivities().size() > ActivityBuffer.BUFFER_SIZE) {                  
-                errors.add("buffer is full.");
-           }
+           } 
            if (t.getEvent() != null) {
                errors.add("Activity can exist only in event OR in buffer");
            }

--- a/src/main/java/partio/service/validators/Validator.java
+++ b/src/main/java/partio/service/validators/Validator.java
@@ -11,7 +11,7 @@ public abstract class Validator<T> {
     protected static final boolean NOT_NULL = true;
 
     public abstract List<String> validateNew(T t);
-    public abstract List<String> validateChanges(Event original, Event changes);
+    public abstract List<String> validateChanges(T original, T changes);
     protected abstract List<String> validateNewAndOld(T t);
     
     protected boolean validateStringLength(String toValidate, int min, int max, boolean notNull) {


### PR DESCRIPTION
TO USE (there is only 1buffer existing and configured to be always found) but it's good practice to prepare for multiclient support...My point is bufferid does not matter at the moment it's kinda singleton atm)

in addition to regular put request (set activity attributes in frontend then validate and save in backend)

Move from buffer to event. Requirements activity to belong to event
--put empty body-- 
http://localhost:3001/activity/1/frombuffer/1/toevent/1

Move from event to to buffer. Requirements activity to belong to buffer and an event to exist
--put empty body-- 
http://localhost:3001/activity/1/fromevent/1/tobuffer/1